### PR TITLE
Feature/sync snippets with snippetica

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Simple snippets pack that provides checks for strings and collections. This pack
 | -------- | ------------------------------------------------ |
 | ifsnw    | `if (string.IsNullOrWhiteSpace(str))`            |
 | ifsnwb   | `if (string.IsNullOrWhiteSpace(str)) {  }`       |
-| ifsnnw   | `if (!string.IsNullOrWhiteSpace(str))`           |
-| ifsnnwb  | `if (!string.IsNullOrWhiteSpace(str)) {  }`      |
+| ifxsnw   | `if (!string.IsNullOrWhiteSpace(str))`           |
+| ifxsnwb  | `if (!string.IsNullOrWhiteSpace(str)) {  }`      |
 | csnw     | `string.IsNullOrWhiteSpace(str) ? true : false`  |
-| csnnw    | `!string.IsNullOrWhiteSpace(str) ? true : false` |
+| cxsnw    | `!string.IsNullOrWhiteSpace(str) ? true : false` |
 
 
 ## Collection check snippets using Linq methods
@@ -22,20 +22,20 @@ Simple snippets pack that provides checks for strings and collections. This pack
 | ifanyc   | `if (collection.Any(i => <condition>))`            |
 | ifanyb   | `if (collection.Any()) {}`                         |
 | ifanycb  | `if (collection.Any(i => <condition>)) { }`        |
-| ifnany   | `if (!collection.Any())`                           |
-| ifnanyc  | `if (!collection.Any(i => <condition>))`           |
-| ifnanyb  | `if (!collection.Any()) {}`                        |
-| ifnanycb | `if (!collection.Any(i => <condition>)) { }`       |
+| ifxany   | `if (!collection.Any())`                           |
+| ifxanyc  | `if (!collection.Any(i => <condition>))`           |
+| ifxanyb  | `if (!collection.Any()) {}`                        |
+| ifxanycb | `if (!collection.Any(i => <condition>)) { }`       |
 | ifall    | `if (collection.All(i => <condition>))`            |
 | ifallb   | `if (collection.All(i => <condition>)) { }`        |
-| ifnall   | `if (!collection.All(i => <condition>))`           |
-| ifnallb  | `if (!collection.All(i => <condition>)) { }`       |
+| ifxall   | `if (!collection.All(i => <condition>))`           |
+| ifxallb  | `if (!collection.All(i => <condition>)) { }`       |
 | cany     | `collection.Any() ? true : false`                  |
 | canyc    | `collection.Any(i => <condition>) ? true : false`  |
-| cnany    | `!collection.Any() ? true : false`                 |
-| cnanyc   | `!collection.Any(i => <condition>) ? true : false` |
+| cxany    | `!collection.Any() ? true : false`                 |
+| cxanyc   | `!collection.Any(i => <condition>) ? true : false` |
 | call     | `collection.All(i => <condition>) ? true : false`  |
-| cnall    | `!collection.All(i => <condition>) ? true : false` |
+| cxall    | `!collection.All(i => <condition>) ? true : false` |
 
 ## Collection check snippets by Length and Count properties with null check
 

--- a/USnippetPack.VS2022/source.extension.vsixmanifest
+++ b/USnippetPack.VS2022/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="uSnippetPack.cd839adc-ef78-496a-a991-22769f2f4cd1" Version="1.1.1" Language="en-US" Publisher="Sergei Zaitsev"/>
+    <Identity Id="uSnippetPack.cd839adc-ef78-496a-a991-22769f2f4cd1" Version="2.0" Language="en-US" Publisher="Sergei Zaitsev"/>
     <DisplayName>uSnippetPack</DisplayName>
     <Description xml:space="preserve">Simple c# snippet pack for Visual Studio 2022</Description>
     <MoreInfo>https://github.com/za9cser</MoreInfo>

--- a/USnippetPack.VS2022/uSnippetPack.CSharp/ConditionalNoAnyItemsInCollection.snippet
+++ b/USnippetPack.VS2022/uSnippetPack.CSharp/ConditionalNoAnyItemsInCollection.snippet
@@ -9,7 +9,7 @@
 			<Author>Sergei Zaitsev</Author>
 			<Description>conditional operator with condition whether collection hasn't items
       </Description>
-			<Shortcut>cnany</Shortcut>
+			<Shortcut>cxany</Shortcut>
 		</Header>
 		<Snippet>
 			<Imports>

--- a/USnippetPack.VS2022/uSnippetPack.CSharp/ConditionalNoAnyItemsWithConditionInCollection.snippet
+++ b/USnippetPack.VS2022/uSnippetPack.CSharp/ConditionalNoAnyItemsWithConditionInCollection.snippet
@@ -8,7 +8,7 @@
 			<Title>conditional operator collection any items don't matсh condition</Title>
 			<Author>Sergei Zaitsev</Author>
 			<Description>conditional operator with condition whether collection any items don't matсh condition</Description>
-			<Shortcut>cnanyc</Shortcut>
+			<Shortcut>cxanyc</Shortcut>
 		</Header>
 		<Snippet>
 			<Imports>

--- a/USnippetPack.VS2022/uSnippetPack.CSharp/ConditionalNotAllItemsInCollection.snippet
+++ b/USnippetPack.VS2022/uSnippetPack.CSharp/ConditionalNotAllItemsInCollection.snippet
@@ -8,7 +8,7 @@
 			<Title>conditional operator collection all items don't matсh condition</Title>
 			<Author>Sergei Zaitsev</Author>
 			<Description>conditional operator with condition whether collection all items don't matсh condition</Description>
-			<Shortcut>cnall</Shortcut>
+			<Shortcut>cxall</Shortcut>
 		</Header>
 		<Snippet>
 			<Imports>

--- a/USnippetPack.VS2022/uSnippetPack.CSharp/ConditionalStringIsNotNullOrWhitespace.snippet
+++ b/USnippetPack.VS2022/uSnippetPack.CSharp/ConditionalStringIsNotNullOrWhitespace.snippet
@@ -8,7 +8,7 @@
 			<Title>conditional operator string is not null or whitespace</Title>
 			<Author>Sergei Zaitsev</Author>
 			<Description>conditional operator with condition whether string is not null or whitespace</Description>
-			<Shortcut>csnnw</Shortcut>
+			<Shortcut>cxsnw</Shortcut>
 		</Header>
 		<Snippet>
 			<Declarations>

--- a/USnippetPack.VS2022/uSnippetPack.CSharp/IfNoAnyItemsInCollection.snippet
+++ b/USnippetPack.VS2022/uSnippetPack.CSharp/IfNoAnyItemsInCollection.snippet
@@ -8,7 +8,7 @@
 			<Title>if collection hasn't any items</Title>
 			<Author>Sergei Zaitsev</Author>
 			<Description>if statement to check collection hasn't any items</Description>
-			<Shortcut>ifnany</Shortcut>
+			<Shortcut>ifxany</Shortcut>
 		</Header>
 		<Snippet>
 			<Imports>

--- a/USnippetPack.VS2022/uSnippetPack.CSharp/IfNoAnyItemsInCollectionBraces.snippet
+++ b/USnippetPack.VS2022/uSnippetPack.CSharp/IfNoAnyItemsInCollectionBraces.snippet
@@ -8,7 +8,7 @@
 			<Title>if collection hasn't any items w/ braces</Title>
 			<Author>Sergei Zaitsev</Author>
 			<Description>if statement to check collection hasn't any items w/ braces</Description>
-			<Shortcut>ifnanyb</Shortcut>
+			<Shortcut>ifxanyb</Shortcut>
 		</Header>
 		<Snippet>
 			<Imports>

--- a/USnippetPack.VS2022/uSnippetPack.CSharp/IfNoAnyItemsWithConditionInCollection.snippet
+++ b/USnippetPack.VS2022/uSnippetPack.CSharp/IfNoAnyItemsWithConditionInCollection.snippet
@@ -1,4 +1,4 @@
-﻿s<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <CodeSnippets xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
 	<CodeSnippet Format="1.0.0">
 		<Header>

--- a/USnippetPack.VS2022/uSnippetPack.CSharp/IfNoAnyItemsWithConditionInCollectionBraces.snippet
+++ b/USnippetPack.VS2022/uSnippetPack.CSharp/IfNoAnyItemsWithConditionInCollectionBraces.snippet
@@ -8,7 +8,7 @@
 			<Title>if collection items dont't matсh condition in Any() method  w/ braces</Title>
 			<Author>Sergei Zaitsev</Author>
 			<Description>if statement to check collection items don't matсh condition in Any() method w/ braces</Description>
-			<Shortcut>ifnanycb</Shortcut>
+			<Shortcut>ifxanycb</Shortcut>
 		</Header>
 		<Snippet>
 			<Imports>

--- a/USnippetPack.VS2022/uSnippetPack.CSharp/IfNotAllItemsInCollection.snippet
+++ b/USnippetPack.VS2022/uSnippetPack.CSharp/IfNotAllItemsInCollection.snippet
@@ -8,7 +8,7 @@
 			<Title>if collection all items don't matсh condition</Title>
 			<Author>Sergei Zaitsev</Author>
 			<Description>if statement to check collection all items don't matсh condition</Description>
-			<Shortcut>ifnall</Shortcut>
+			<Shortcut>ifxall</Shortcut>
 		</Header>
 		<Snippet>
 			<Imports>

--- a/USnippetPack.VS2022/uSnippetPack.CSharp/IfNotAllItemsInCollectionBraces.snippet
+++ b/USnippetPack.VS2022/uSnippetPack.CSharp/IfNotAllItemsInCollectionBraces.snippet
@@ -8,7 +8,7 @@
 			<Title>if collection all items dont't matсh condition w/ braces</Title>
 			<Author>Sergei Zaitsev</Author>
 			<Description>if statement to check collection all items don't matсh condition w/ braces</Description>
-			<Shortcut>ifnallcb</Shortcut>
+			<Shortcut>ifxallcb</Shortcut>
 		</Header>
 		<Snippet>
 			<Imports>

--- a/USnippetPack.VS2022/uSnippetPack.CSharp/IfStringIsNotNullOrWhitespace.snippet
+++ b/USnippetPack.VS2022/uSnippetPack.CSharp/IfStringIsNotNullOrWhitespace.snippet
@@ -8,7 +8,7 @@
 			<Title>if string is not not null or whitespace</Title>
 			<Author>Sergei Zaitsev</Author>
 			<Description>if statement string is not not null or whitespace</Description>
-			<Shortcut>ifsnnw</Shortcut>
+			<Shortcut>ifxsnw</Shortcut>
 		</Header>
 		<Snippet>
 			<Declarations>

--- a/USnippetPack.VS2022/uSnippetPack.CSharp/IfStringIsNotNullOrWhitespaceBraces.snippet
+++ b/USnippetPack.VS2022/uSnippetPack.CSharp/IfStringIsNotNullOrWhitespaceBraces.snippet
@@ -8,7 +8,7 @@
 			<Title>if string is not null or whitespace w/ braces</Title>
 			<Author>Sergei Zaitsev</Author>
 			<Description>if statement to check string is not null or whitespace w/ braces</Description>
-			<Shortcut>ifsnnwb</Shortcut>
+			<Shortcut>ifxsnwb</Shortcut>
 		</Header>
 		<Snippet>
 			<Declarations>


### PR DESCRIPTION
all snippets with inversion synced with Snippetica to use 'x' instead of 'n'. For example, ifsnnw synced to ifxsnw